### PR TITLE
Added createdAt to reputation mint and burn

### DIFF
--- a/packages/subgraph/src/mappings/Reputation/mapping.ts
+++ b/packages/subgraph/src/mappings/Reputation/mapping.ts
@@ -75,6 +75,7 @@ export function handleMint(event: Mint): void {
   ent.contract = event.address;
   ent.address = event.params._to;
   ent.amount = event.params._amount;
+  ent.createdAt = event.block.timestamp;
 
   store.set('ReputationMint', ent.id, ent);
 }
@@ -88,6 +89,7 @@ export function handleBurn(event: Burn): void {
   ent.contract = event.address;
   ent.address = event.params._from;
   ent.amount = event.params._amount;
+  ent.createdAt = event.block.timestamp;
 
   store.set('ReputationBurn', ent.id, ent);
 }

--- a/packages/subgraph/src/mappings/Reputation/schema.graphql
+++ b/packages/subgraph/src/mappings/Reputation/schema.graphql
@@ -20,6 +20,7 @@ type ReputationMint @entity {
 	contract: Bytes!
 	address: Bytes!
 	amount: BigInt!
+	createdAt: BigInt!
 }
 
 type ReputationBurn @entity {
@@ -28,4 +29,5 @@ type ReputationBurn @entity {
 	contract: Bytes!
 	address: Bytes!
 	amount: BigInt!
+	createdAt: BigInt!
 }


### PR DESCRIPTION
I added a createdAt field with the timestamp of the reputation mint and burn. This way we can query mints/burns in a period of time.

This modification is deployed in The Graph at [grasia/daostack](https://thegraph.com/hosted-service/subgraph/grasia/daostack) and [grasia/daostack-xdai](https://thegraph.com/hosted-service/subgraph/grasia/daostack-xdai)

It's currently syncing, that's why the PR is just a draft.